### PR TITLE
Pass location of manifest file to the click build command

### DIFF
--- a/clickable
+++ b/clickable
@@ -448,7 +448,7 @@ class Clickable(object):
             print_success('Finished setting up the lxd container')
 
     def click_build(self):
-        command = 'click build {} --no-validate'.format(self.temp)
+        command = 'click build {} --no-validate'.format(os.path.dirname(self.find_manifest()))
 
         if self.config.chroot:
             subprocess.check_call(shlex.split(command), cwd=self.config.dir)


### PR DESCRIPTION
Do not assume that the manifest file is located at the root of the build
directory.

Fixes #13