### PR TITLE
Add support for docker-ce package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          adb,
-         docker.io,
+         docker.io | docker-ce,
          python
 Suggests: docker
 Description: Compile, build, and deploy Ubuntu Touch click packages all from the command line.


### PR DESCRIPTION
I tested that the docker-ce package from the official docker repository also works.

Btw, why did you add the `-0ubuntu1~unstable` revision in the changelog? The package refuses to build now as in debian, only quilt packages may have a revision. Is that somehow needed for Launchpad?