### PR TITLE
Remove "docker" suggestion and replace it by lxd and ubuntu-sdk-tools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,5 +13,6 @@ Depends: ${shlibs:Depends},
          adb,
          docker.io | docker-ce,
          python
-Suggests: docker
+Suggests: lxd,
+          ubuntu-sdk-tools
 Description: Compile, build, and deploy Ubuntu Touch click packages all from the command line.


### PR DESCRIPTION
The docker package is "WindowMaker dock app" (I don't think we need it here), lxd seems to be still supported in clickable so adding it to suggestions makes sense.