### PR TITLE
add bash -c "{}" to wrapped command for container-mode and chroot

### DIFF
--- a/clickable
+++ b/clickable
@@ -365,35 +365,36 @@ class Clickable(object):
     def run_container_command(self, command, force_lxd=False, sudo=False, get_output=False, use_dir=True):
         wrapped_command = command
 
-        if not self.config.container_mode:
-            if force_lxd or self.config.lxd:
-                self.check_lxd()
+        if self.config.container_mode:
+            wrapped_command = 'bash -c "{}"'.format(command);
+        elif force_lxd or self.config.lxd:
+            self.check_lxd()
 
-                target_command = 'exec'
-                if sudo:
-                    target_command = 'maint'
+            target_command = 'exec'
+            if sudo:
+                target_command = 'maint'
 
-                if use_dir:
-                    command = 'cd {}; {}'.format(self.config.dir, command)
+            if use_dir:
+                command = 'cd {}; {}'.format(self.config.dir, command)
 
-                wrapped_command = 'usdk-target {} clickable-{} -- bash -c "{}"'.format(target_command, self.build_arch, command)
-            elif self.config.chroot:
-                chroot_command = 'run'
-                if sudo:
-                    chroot_command = 'maint'
+            wrapped_command = 'usdk-target {} clickable-{} -- bash -c "{}"'.format(target_command, self.build_arch, command)
+        elif self.config.chroot:
+            chroot_command = 'run'
+            if sudo:
+                chroot_command = 'maint'
 
-                wrapped_command = 'click chroot -a {} -f {} {} {}'.format(self.build_arch, self.config.sdk, chroot_command, command)
-            else:  # Docker
-                self.check_docker()
+            wrapped_command = 'click chroot -a {} -f {} {} bash -c "{}"'.format(self.build_arch, self.config.sdk, chroot_command, command)
+        else:  # Docker
+            self.check_docker()
 
-                wrapped_command = 'docker run -v {}:{} -w {} -u {} --rm -i {} bash -c "{}"'.format(
-                    self.cwd,
-                    self.cwd,
-                    self.config.dir,
-                    os.getuid(),
-                    self.docker_image,
-                    command,
-                )
+            wrapped_command = 'docker run -v {}:{} -w {} -u {} --rm -i {} bash -c "{}"'.format(
+                self.cwd,
+                self.cwd,
+                self.config.dir,
+                os.getuid(),
+                self.docker_image,
+                command,
+            )
 
         kwargs = {}
         if use_dir:


### PR DESCRIPTION
commands containing pipes are not properly executed otherwise

added: 
`if self.config.container_mode:`
`wrapped_command = 'bash -c "{}"'.format(command);`

changed (chroot):
`wrapped_command = 'click chroot -a {} -f {} {} {}'.format(self.build_arch, self.config.sdk, chroot_command, command)`
to
`wrapped_command = 'click chroot -a {} -f {} {} bash -c "{}"'.format(self.build_arch, self.config.sdk, chroot_command, command)`

the rest is just indenting

this solved the dependency check for --container-mode and chroot

---

current version, without dependency installed:

root@badd94a0aaf5:/home/chris/git/fahrplan# ./clickable --container-mode
Skipping kill, running in container mode
Checking dependencies
dpkg-query: package 'libcurl4-gnutls-dev' is not installed and no information is available
dpkg-query: error: --status needs a valid package name but '|' is not: illegal package name in specifier '|': must start with an alphanumeric character

Use --help for help about querying packages.

--- 
current version, dependency already installed:

root@badd94a0aaf5:/home/chris/git/fahrplan# ./clickable --container-mode
Skipping kill, running in container mode
Checking dependencies
dpkg-query: error: --status needs a valid package name but '|' is not: illegal package name in specifier '|': must start with an alphanumeric character

Use --help for help about querying packages.
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libcurl4-gnutls-dev:armhf is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.

---

new version (this commit):

root@badd94a0aaf5:/home/chris/git/fahrplan# ./clickable --container-mode
Skipping kill, running in container mode
Checking dependencies
Dependencies already installed

  