### PR TITLE
Python3 and pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ stage
 tmp
 _build
 build
+*.egg-info/
+__pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README.md
+
+recursive-include debian *
+recursive-include docker *
+recursive-include docs *
+recursive-include scripts *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@ Compile, build, and deploy Ubuntu Touch click packages all from the command line
 * Update your package list: `sudo apt-get update`
 * Install clickable: `sudo apt-get install clickable`
 
-### Via Git
+### Via Pip && Git
 
 * Install [Docker](https://www.docker.com)
-* Install [Cookiecutter](https://cookiecutter.readthedocs.io/en/latest/installation.html#install-cookiecutter)
-* Clone this repo: `git clone https://github.com/bhdouglass/clickable.git`
-* Add clickable to your PATH: `PATH=$PATH:/path/to/clickable`
-    * It is recommended to save this to your `~/.bashrc`
+* Install: `sudo apt-get install python3-pip`
+* Run: `sudo pip3 install https://github.com/bhdouglass/clickable.git`
 
 ### Post Setup
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compile, build, and deploy Ubuntu Touch click packages all from the command line
 
 * Install [Docker](https://www.docker.com)
 * Install: `sudo apt-get install python3-pip`
-* Run: `sudo pip3 install https://github.com/bhdouglass/clickable.git`
+* Run: `sudo pip3 install git+https://github.com/bhdouglass/clickable.git`
 
 ### Post Setup
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: clickable
 Section: devel
 Priority: optional
 Maintainer: JBBgameich <jbb.mail@gmx.de>
-Build-Depends: debhelper (>= 9), help2man, dpkg-dev, python, python-cookiecutter
+Build-Depends: debhelper (>= 9), help2man, dpkg-dev, python3, python3-cookiecutter
 Standards-Version: 4.1.1
 Homepage: https://github.com/bhdouglass/clickable
 
@@ -12,8 +12,8 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          adb | android-tools-adb,
          docker.io | docker-ce,
-         python,
-         python-cookiecutter
+         python3,
+         python3-cookiecutter
 Suggests: lxd,
           ubuntu-sdk-tools
 Description: Compile, build, and deploy Ubuntu Touch click packages all from the command line.

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -4,7 +4,7 @@ rm -rf ./build/
 mkdir -p ./build/tmp/
 
 cp -r debian ./build/tmp/
-cp clickable ./build/tmp/
+cp clickable.py ./build/tmp/clickable
 
 cd ./build/
 docker run -v `pwd`:`pwd` -w `pwd` -u `id -u` --rm -it clickable/build-deb bash -c "cd tmp && dpkg-buildpackage"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import ast
+import re
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+readme = open('README.md').read()
+
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
+
+with open('clickable.py', 'rb') as f:
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
+
+requirements = [
+    "cookiecutter",
+]
+
+test_requirements = [
+    "ipdb",
+]
+
+setup(
+    name='clickable',
+    version=version,
+    description='Compile, build, and deploy Ubuntu Touch click packages all'
+                'from the command line.',
+    long_description=readme,
+    author='Brian Douglass',
+    url='https://github.com/bhdouglass/clickable',
+    py_modules=['clickable'],
+    include_package_data=True,
+    install_requires=requirements,
+    license="GPL3",
+    zip_safe=False,
+    keywords='click ubuntu touch ubports',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+    ],
+    test_suite='tests',
+    tests_require=test_requirements,
+    entry_points={
+        "console_scripts": [
+            "clickable = clickable:main",
+        ],
+    }
+)


### PR DESCRIPTION
I ported the code to `python3` and made it `pip install` compatible (`setup.py`). It is now possible to install it via:

```
$ pip install -e git+https://github.com/delijati/clickable
$ clickable --help
```

This package should also be registered on https://pypi.python.org/pypi

For further work, restructuring the package should get module aka:
```
- setup.py
- README.md
- clickable/
    - cli.py
    - clickable.py
    - config.py
    - ...
```