### PR TITLE
16.04-sdk: use amd64 version of qttools5-dev-tools rather than armhf

### DIFF
--- a/docker/ubuntu-sdk/16.04-armhf/Dockerfile
+++ b/docker/ubuntu-sdk/16.04-armhf/Dockerfile
@@ -119,7 +119,7 @@ RUN apt-get -y --no-install-recommends install \
     qt5-qmake-arm-linux-gnueabihf \
     ubuntu-sdk-qmake-extras:armhf \
     intltool:armhf \
-    qttools5-dev-tools:armhf \
+    qttools5-dev-tools:amd64 \
     oxideqt-codecs-extra \
     language-pack-en \
     click \


### PR DESCRIPTION
At least lupdate and lrelease from this package are needed as amd64 version to generate translations.