### PR TITLE
Update debian packaging for setuptools

### DIFF
--- a/debian/clickable.install
+++ b/debian/clickable.install
@@ -1,1 +1,0 @@
-clickable usr/bin/

--- a/debian/control
+++ b/debian/control
@@ -2,18 +2,17 @@ Source: clickable
 Section: devel
 Priority: optional
 Maintainer: JBBgameich <jbb.mail@gmx.de>
-Build-Depends: debhelper (>= 9), help2man, dpkg-dev, python3, python3-cookiecutter
+Build-Depends: debhelper (>= 9), dh-python, help2man, dpkg-dev, python3 (>= 3.3), python3-cookiecutter, python3-ipdb
 Standards-Version: 4.1.1
 Homepage: https://github.com/bhdouglass/clickable
+X-Python3-Version: >= 3.3
 
 Package: clickable
 Architecture: all
-Depends: ${shlibs:Depends},
+Depends: ${python3:Depends},
          ${misc:Depends},
          adb | android-tools-adb,
          docker.io | docker-ce,
-         python3,
-         python3-cookiecutter
 Suggests: lxd,
           ubuntu-sdk-tools
 Description: Compile, build, and deploy Ubuntu Touch click packages all from the command line.

--- a/debian/rules
+++ b/debian/rules
@@ -3,12 +3,12 @@ include /usr/share/dpkg/pkg-info.mk
 PKGDIR=debian/clickable
 
 %:
-	dh $@
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_install:
 	dh_install
 
-	# Install the manpages
+	# Install the manpage
 	mkdir -p $(PKGDIR)/usr/share/man/man1/
 	help2man $(PKGDIR)/usr/bin/clickable \
 	--no-info \

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-rm -rf ./build/
-mkdir -p ./build/tmp/
-
-cp -r debian ./build/tmp/
-cp clickable.py ./build/tmp/clickable
-
-cd ./build/
 docker run -v `pwd`:`pwd` -w `pwd` -u `id -u` --rm -it clickable/build-deb:python3 bash -c "cd tmp && dpkg-buildpackage"

--- a/scripts/publish_deb.sh
+++ b/scripts/publish_deb.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-rm -rf ./build/
-mkdir -p ./build/tmp/
+# Prepare for upload and build source package
+sed -i 's/unstable/artful/g' debian/changelog
 
-cp -r debian ./build/tmp/
-cp clickable.py ./build/tmp/clickable
-
-cd ./build/
-
-sed -i 's/unstable/artful/g' ./build/tmp/debian/changelog
-
-cd build/tmp
 debuild -S
 dput ppa:bhdouglass/clickable ../clickable_*_source.changes
+
+# Clean up
+dh_clean
+sed -i 's/artful/unstable/g' debian/changelog

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
-    test_suite='tests',
     tests_require=test_requirements,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
The debian packaging scripts were a little bit hacky. I'd like to get clickable into the official debian repository one day, so being compliant with their policy makes sense to me.