### PR TITLE
Revamp cordova build process to work completely independently of machine

### DIFF
--- a/clickable.py
+++ b/clickable.py
@@ -1232,15 +1232,7 @@ class CordovaClickable(CMakeClickable):
         self.config.specificDependencies = True
         self.config.dependencies = [ # Got this list from check_reqs or somewhere
                 "libicu-dev:armhf",
-                "pkg-config",
-                "qtbase5-dev:armhf",
-                "qtchooser",
-                "qtdeclarative5-dev:armhf",
                 "qtfeedback5-dev:armhf",
-                "qtlocation5-dev:armhf",
-                "qtmultimedia5-dev:armhf",
-                "qtpim5-dev:armhf",
-                "libqt5sensors5-dev:armhf",
                 "qtsystems5-dev:armhf"
         ]
 

--- a/clickable.py
+++ b/clickable.py
@@ -1229,7 +1229,6 @@ class CordovaClickable(CMakeClickable):
 
         self.config.specificDependencies = True
         self.config.dependencies = [ # Got this list from check_reqs or somewhere
-                "cmake",
                 "libicu-dev:armhf",
                 "pkg-config",
                 "qtbase5-dev:armhf",

--- a/clickable.py
+++ b/clickable.py
@@ -1214,17 +1214,25 @@ class GoClickable(Clickable):
         self.run_container_command(gocommand)
 
 
-class CordovaClickable(Clickable):
+class CordovaClickable(CMakeClickable):
+    # build dir  = platforms/ubuntu/<framework>-<arch>/build
+    # prefix dir = platforms/ubuntu/<framework>-<arch>/prefix
+    # make dir   = platforms/ubuntu/build
+    def __init__(self, *args, **kwargs):
+        super(CMakeClickable, self).__init__(*args, **kwargs)
+
+        # TODO: change self.temp to point to build dir so compiled stuff goes
+        # there
+
     def _build(self):
-        command = "cordova -d build ubuntu --device -- --framework={}".format(self.config.sdk)
-        subprocess.check_call(shlex.split(command), cwd=self.cwd)
+        # TODO: go into make directory
+        super(CMakeClickable, self)._build()
 
     def click_build(self):
-        click = '{}_{}_{}.click'.format(self.find_package_name(), self.find_version(), self.config.arch)
-        src = '{}/platforms/ubuntu/{}/{}/prefix/{}'.format(self.cwd, self.config.sdk, self.config.arch, click)
-        dest = '{}/{}'.format(self.config.dir, click)
+        # TODO: go into prefix directory
+        # TODO: change manifest file (framework + architecture)
 
-        shutil.copyfile(src, dest)
+        super(CMakeClickable, self).click_build()
 
     def find_package_name(self):
         tree = ElementTree.parse('config.xml')

--- a/clickable.py
+++ b/clickable.py
@@ -1242,8 +1242,6 @@ class CordovaClickable(CMakeClickable):
                 "qtsystems5-dev:armhf"
         ]
 
-    def _build(self):
-
         if not os.path.isdir(self.platform_dir):
             # fail when not using docker, need it anyways
             if self.config.container_mode or self.config.lxd or self.config.chroot:
@@ -1262,6 +1260,9 @@ class CordovaClickable(CMakeClickable):
             subprocess.check_call(shlex.split(wrapped_command))
 
         self.config.dir = self._dirs['prefix']
+
+    def _build(self):
+
         # Clear out prefix directory
         # IK this is against DRY, but I copied this code from MakeClickable.make_install
         if os.path.exists(self.config.dir) and os.path.isdir(self.temp):
@@ -1323,11 +1324,6 @@ class CordovaClickable(CMakeClickable):
     def make_install(self):
         # This is beause I don't want a DESTDIR
         self.run_container_command('make install')
-
-    def click_build(self):
-        self.config.dir = self._dirs['prefix']
-
-        super(CordovaClickable, self).click_build()
 
     def find_manifest(self):
         return find_manifest(self._dirs['build'])

--- a/clickable.py
+++ b/clickable.py
@@ -1246,7 +1246,9 @@ class CordovaClickable(CMakeClickable):
 
         if not os.path.isdir(self.platform_dir):
             # fail when not using docker, need it anyways
-            assert not (self.config.container_mode or self.config.lxd or self.config.chroot), "Need docker"
+            if self.config.container_mode or self.config.lxd or self.config.chroot:
+                print_error('Docker is required to intialize cordova directories. Enable docker or run "cordova platform add ubuntu" manually to remove this message')
+                sys.exit(1)
 
             cordova_docker_image = "beevelop/cordova:v7.0.0"
             command = "cordova platform add ubuntu; chown -R {uid}:{uid} platforms plugins node_modules".format(uid=os.getuid())

--- a/clickable.py
+++ b/clickable.py
@@ -1212,6 +1212,8 @@ class GoClickable(Clickable):
 
 
 class CordovaClickable(CMakeClickable):
+    # Lots of this code was based off of this:
+    # https://github.com/apache/cordova-ubuntu/blob/28cd3c1b53c1558baed4c66cb2deba597f05b3c6/bin/templates/project/cordova/lib/build.js#L59-L131
     def __init__(self, *args, **kwargs):
         super(CMakeClickable, self).__init__(*args, **kwargs)
 

--- a/clickable.py
+++ b/clickable.py
@@ -1311,10 +1311,7 @@ class CordovaClickable(CMakeClickable):
         apparmor_file = os.path.join(self._dirs['build'], 'apparmor.json')
         with open(apparmor_file, 'r') as apparmor_reader:
             apparmor = json.load(apparmor_reader)
-            if self.config.sdk == "ubuntu-sdk-14.10":
-                apparmor["policy_version"] = 1.2
-            else:
-                apparmor["policy_version"] = 1.3
+            apparmor["policy_version"] = 1.3
 
             if 'webview' not in apparmor["policy_groups"]:
                 apparmor["policy_groups"].append("webview")

--- a/clickable.py
+++ b/clickable.py
@@ -1248,6 +1248,7 @@ class CordovaClickable(CMakeClickable):
         # TODO: also spool up a cordova container to regenerate plugins and
         # platforms:
         # `docker run --rm -v $PWD:$PWD -w $PWD beevelop/cordova:v7.0.0 bash -c 'cordova platform add ubuntu; cordova platform build; chown -R 1000:1000 platforms plugins'`
+
         self.config.dir = self._dirs['prefix']
         # Clear out prefix directory
         # IK this is against DRY, but I copied this code from MakeClickable.make_install
@@ -1266,7 +1267,13 @@ class CordovaClickable(CMakeClickable):
     def post_make(self):
         super(CordovaClickable, self).post_make()
 
-        copies = ['www', 'config.xml', 'cordova.desktop', 'manifest.json', 'apparmor.json']
+        copies = [
+            'www',
+            'config.xml',
+            'cordova.desktop',
+            'manifest.json',
+            'apparmor.json'
+        ]
 
         # Is this overengineerd?
         for file_to_copy in copies:
@@ -1301,13 +1308,9 @@ class CordovaClickable(CMakeClickable):
             with open(apparmor_file, 'w') as apparmor_writer:
                 json.dump(apparmor, apparmor_writer, indent=4)
 
-
-
-
-
-
     def make_install(self):
-        self.run_container_command('make install') # This is beause I don't want a DESTDIR
+        # This is beause I don't want a DESTDIR
+        self.run_container_command('make install')
 
     def click_build(self):
         self.config.dir = self._dirs['prefix']

--- a/clickable.py
+++ b/clickable.py
@@ -1218,13 +1218,15 @@ class CordovaClickable(CMakeClickable):
     def __init__(self, *args, **kwargs):
         super(CMakeClickable, self).__init__(*args, **kwargs)
 
-        platform_dir = os.path.join(self.cwd, 'platforms/ubuntu/')
+        self.platform_dir = os.path.join(self.cwd, 'platforms/ubuntu/')
 
         self._dirs = {
-                'build'  : '{}/{}/{}/build/' .format(platform_dir, self.config.sdk, self.build_arch),
-                'prefix' : '{}/{}/{}/prefix/'.format(platform_dir, self.config.sdk, self.build_arch),
-                'make'   : '{}/build'.format(platform_dir)
+                'build'  : '{}/{}/{}/build/' .format(self.platform_dir, self.config.sdk, self.build_arch),
+                'prefix' : '{}/{}/{}/prefix/'.format(self.platform_dir, self.config.sdk, self.build_arch),
+                'make'   : '{}/build'.format(self.platform_dir)
         }
+
+        self.temp = self._dirs['build']
 
         self.config.specificDependencies = True
         self.config.dependencies = [ # Got this list from check_reqs or somewhere

--- a/clickable.py
+++ b/clickable.py
@@ -1316,7 +1316,8 @@ class CordovaClickable(CMakeClickable):
             else:
                 apparmor["policy_version"] = 1.3
 
-            apparmor["policy_groups"].append("webview")
+            if 'webview' not in apparmor["policy_groups"]:
+                apparmor["policy_groups"].append("webview")
 
             with open(apparmor_file, 'w') as apparmor_writer:
                 json.dump(apparmor, apparmor_writer, indent=4)

--- a/clickable.py
+++ b/clickable.py
@@ -1249,7 +1249,16 @@ class CordovaClickable(CMakeClickable):
         # platforms:
         # `docker run --rm -v $PWD:$PWD -w $PWD beevelop/cordova:v7.0.0 bash -c 'cordova platform add ubuntu; cordova platform build; chown -R 1000:1000 platforms plugins'`
         self.config.dir = self._dirs['prefix']
-        #         var cmakeCmd = 'cmake ' + campoDir + ' -DCMAKE_INSTALL_PREFIX="' + prefixDir + '"' + ' -DCMAKE_BUILD_TYPE=' + buildType; # from build.js
+        # Clear out prefix directory
+        # IK this is against DRY, but I copied this code from MakeClickable.make_install
+        if os.path.exists(self.config.dir) and os.path.isdir(self.temp):
+            shutil.rmtree(self.config.dir)
+
+        try:
+            os.makedirs(self.config.dir)
+        except Exception:
+            print_warning('Failed to create temp dir ({}): {}'.format(self.temp, str(sys.exc_info()[0])))
+
         self.run_container_command('cmake {} -DCMAKE_INSTALL_PREFIX={}'.format(self._dirs['make'], self._dirs['build']))
         super(CMakeClickable, self)._build()
 

--- a/clickable.py
+++ b/clickable.py
@@ -13,6 +13,8 @@ import uuid
 import xml.etree.ElementTree as ElementTree
 import getpass
 
+from distutils.dir_util import copy_tree
+
 cookiecutter_available = True
 try:
     from cookiecutter.main import cookiecutter
@@ -1294,7 +1296,6 @@ class CordovaClickable(CMakeClickable):
             full_dest_path = os.path.join(self._dirs['build'], file_to_copy)
             if os.path.isdir(full_source_path):
                 # https://stackoverflow.com/a/31039095/6381767
-                from distutils.dir_util import copy_tree
                 copy_tree(full_source_path, full_dest_path)
             else:
                 shutil.copy(full_source_path, full_dest_path)

--- a/clickable.py
+++ b/clickable.py
@@ -1243,11 +1243,12 @@ class CordovaClickable(CMakeClickable):
                 sys.exit(1)
 
             cordova_docker_image = "beevelop/cordova:v7.0.0"
-            command = "cordova platform add ubuntu; chown -R {uid}:{uid} platforms plugins node_modules".format(uid=os.getuid())
+            command = "cordova platform add ubuntu"
 
-            # Can't use self.run_container_command because need root
-            wrapped_command = 'docker run -v {cwd}:{cwd} -w {cwd} --rm -i {img} bash -c "{cmd}"'.format(
+            # Can't use self.run_container_command because need to set -e HOME=/tmp
+            wrapped_command = 'docker run -v {cwd}:{cwd} -w {cwd} -u {uid}:{uid} -e HOME=/tmp --rm -i {img} {cmd}'.format(
                     cwd=self.cwd,
+                    uid=os.getuid(),
                     img=cordova_docker_image,
                     cmd=command)
 

--- a/clickable.py
+++ b/clickable.py
@@ -317,9 +317,6 @@ class Clickable(object):
             else:
                 self.check_command('adb')
 
-        if self.config.template == Config.CORDOVA:
-            self.check_command('cordova')
-
         if 'SNAP' in os.environ and os.environ['SNAP']:
             # If running as a snap, trick usdk-target into thinking its not in a snap
             del os.environ['SNAP']


### PR DESCRIPTION
Getting up a working Cordova environment was a pain, and so I added on to the `ClickableCordova` class a bit to get a working compilation process in containers.

What I basically did was rewrite [this](https://github.com/apache/cordova-ubuntu/blob/28cd3c1b53c1558baed4c66cb2deba597f05b3c6/bin/templates/project/cordova/lib/build.js#L59-L131) for clickable, as cordova uses `click chroot` & other stuff that doesnt work

This solves both #52 and #53, and doesn't require cordova installed on the host machine at all