### PR TITLE
Cordova bug fixes

### DIFF
--- a/clickable.py
+++ b/clickable.py
@@ -1273,18 +1273,25 @@ class CordovaClickable(CMakeClickable):
     def post_make(self):
         super(CordovaClickable, self).post_make()
 
-        copies = [
-            'www',
-            'config.xml',
-            'cordova.desktop',
-            'manifest.json',
-            'apparmor.json'
-        ]
+        copies = {
+                "www": None,
+                "platform_www": "www",
+                "config.xml": None,
+                "cordova.desktop": None,
+                "manifest.json": None,
+                "apparmor.json": None,
+                }
+
+        # If value is none, set to key
+        copies = {key: key if value is None else value
+                  for key, value in copies.items()}
 
         # Is this overengineerd?
-        for file_to_copy in copies:
-            full_source_path = os.path.join(self.platform_dir, file_to_copy)
-            full_dest_path = os.path.join(self._dirs['build'], file_to_copy)
+        for file_to_copy_source, file_to_copy_dest in copies.items():
+            full_source_path = os.path.join(self.platform_dir,
+                                            file_to_copy_source)
+            full_dest_path = os.path.join(self._dirs['build'],
+                                          file_to_copy_dest)
             if os.path.isdir(full_source_path):
                 # https://stackoverflow.com/a/31039095/6381767
                 copy_tree(full_source_path, full_dest_path)

--- a/clickable.py
+++ b/clickable.py
@@ -1273,6 +1273,10 @@ class CordovaClickable(CMakeClickable):
     def post_make(self):
         super(CordovaClickable, self).post_make()
 
+        www_dir = os.path.join(self.platform_dir, "www")
+        shutil.rmtree(www_dir)
+        shutil.copytree(os.path.join(self.cwd, "www"), www_dir)
+
         copies = {
                 "www": None,
                 "platform_www": "www",

--- a/clickable.py
+++ b/clickable.py
@@ -1276,6 +1276,7 @@ class CordovaClickable(CMakeClickable):
         www_dir = os.path.join(self.platform_dir, "www")
         shutil.rmtree(www_dir)
         shutil.copytree(os.path.join(self.cwd, "www"), www_dir)
+        shutil.copyfile(os.path.join(self.cwd, "config.xml"), www_dir)
 
         copies = {
                 "www": None,

--- a/clickable.py
+++ b/clickable.py
@@ -1276,7 +1276,7 @@ class CordovaClickable(CMakeClickable):
         www_dir = os.path.join(self.platform_dir, "www")
         shutil.rmtree(www_dir)
         shutil.copytree(os.path.join(self.cwd, "www"), www_dir)
-        shutil.copyfile(os.path.join(self.cwd, "config.xml"), www_dir)
+        shutil.copyfile(os.path.join(self.cwd, "config.xml"), os.path.join(www_dir, 'config.xml'))
 
         copies = {
                 "www": None,


### PR DESCRIPTION
Hi, after a few days testing this out with the Cordova patch added, I've encountered a few problems.

Apologies for not catching these on the first PR.

1) on compilation cordova expects both the user provided `www` directory and its own internal `platform_www` to be copied to the `www` directory. Commit bb9871b enables that.

2) On recompilation, the subdirectory `platforms/ubuntu/www` is not updated to reflect changes in root `www` directory. a78c55e fixes this.

I'm sure there will be additional fixes in time, but with these I believe this feature is fully usable (with an already initialized cordova repository)