### PR TITLE
Add qmake/cmake config options to clickable.json

### DIFF
--- a/clickable/build_templates/cmake.py
+++ b/clickable/build_templates/cmake.py
@@ -8,6 +8,11 @@ class CMakeClickable(MakeClickable):
         self.run_container_command('make DESTDIR={} install'.format(self.temp))
 
     def _build(self):
-        self.run_container_command('cmake {}'.format(self.cwd))
+        command = 'cmake'
+
+        if self.config.conf_opts:
+            command = '{} {}'.format(command, self.config.conf_opts)
+
+        self.run_container_command('{} {}'.format(command, self.cwd))
 
         super(CMakeClickable, self)._build()

--- a/clickable/build_templates/qmake.py
+++ b/clickable/build_templates/qmake.py
@@ -20,6 +20,9 @@ class QMakeClickable(MakeClickable):
         else:
             raise Exception('{} is not supported by the qmake build yet'.format(self.build_arch))
 
+        if self.config.conf_opts:
+            command = '{} {}'.format(command, self.config.conf_opts)
+
         self.run_container_command('{} {}'.format(command, self.cwd))
 
         super(QMakeClickable, self)._build()

--- a/clickable/config.py
+++ b/clickable/config.py
@@ -37,6 +37,7 @@ class Config(object):
         'make_jobs': 0,
         'gopath': None,
         'docker_image': None,
+        'conf_opts': None,
     }
 
     PURE_QML_QMAKE = 'pure-qml-qmake'


### PR DESCRIPTION
Accept qmake/cmake config params in clickable.json like that:
```
{
  "template": "qmake",
  "conf_opts": "CONFIG+=ubuntu",
}
```
resulting in `qmake CONFIG+=ubuntu`.